### PR TITLE
Prefer shorter matches in completions

### DIFF
--- a/example/completion.cr
+++ b/example/completion.cr
@@ -3,7 +3,7 @@
 require "../src/linenoise"
 
 Linenoise::Completion.add(["hello", "hello there"])
-Linenoise::Completion.add("hello there everyone")
+Linenoise::Completion.add("howdy")
 Linenoise::Completion.enable_hints!
 
 loop do
@@ -11,6 +11,9 @@ loop do
   break if line.nil?
 
   case line
+  when ":prefer_shorter_matches"
+    Linenoise::Completion.prefer_shorter_matches!
+    puts
   when ":exit", ":quit"
     puts "Bye!"
     break

--- a/expect/completion.expect
+++ b/expect/completion.expect
@@ -68,9 +68,63 @@ expect {
 # Try three tab completions.
 send -h -- "h$tab$tab$tab$newline"
 
-# Expect three tab completions to change "h" to "hello there everyone".
+# Expect three tab completions to change "h" to "howdy".
 expect {
-  -exact "hello there everyone$newline$prompt" {}
+  -exact "howdy$newline$prompt" {}
+  timeout timeout_error
+  eof eof_error
+}
+
+# Try four tab completions.
+send -h -- "h$tab$tab$tab$tab$newline"
+
+# Expect four tab completions to leave "h" unchanged since it
+# has cycled through three tab completions to the original input.
+expect {
+  -exact "h$newline$prompt" {}
+  timeout timeout_error
+  eof eof_error
+}
+
+#
+# Test Tab Completions with Shorter Matches Preferred.
+#
+
+send -h -- ":prefer_shorter_matches$newline"
+
+# Expect prompt to load.
+expect {
+  -exact "$newline$prompt" {}
+  timeout timeout_error
+  eof eof_error
+}
+
+# Try one tab completion.
+send -h -- "h$tab$newline"
+
+# Expect one tab completion to change "h" to "hello".
+expect {
+  -exact "hello$newline$prompt" {}
+  timeout timeout_error
+  eof eof_error
+}
+
+# Try two tab completions.
+send -h -- "h$tab$tab$newline"
+
+# Expect two tab completions to change "h" to "howdy".
+expect {
+  -exact "howdy$newline$prompt" {}
+  timeout timeout_error
+  eof eof_error
+}
+
+# Try three tab completions.
+send -h -- "h$tab$tab$tab$newline"
+
+# Expect three tab completions to change "h" to "hello there".
+expect {
+  -exact "hello there$newline$prompt" {}
   timeout timeout_error
   eof eof_error
 }

--- a/src/linenoise/completions.cr
+++ b/src/linenoise/completions.cr
@@ -4,33 +4,29 @@ module Linenoise
   # A high-level wrapper around the linenoise completions API
   # that makes it easier to add completions to your program.
   module Completion
-    @@hint_color : Int32?
-
     # Memoized completions array that makes it easier to access
     # completions from the completions callback.
     private def self.completions : Array(String)
       @@completions ||= Array(String).new
     end
 
-    # Find the index of the closest match to the given line.
-    private def self.find_index(line : String) : Int32?
-      self.completions.bsearch_index { |string| string >= line }
-    end
-
-    # Yields each completion that begins with the given line as a `String`.
-    # The results are sorted by closest match.
-    private def self.each_completion(line : String, &)
-      return if line.empty?
-
-      index = self.find_index(line)
-      return if index.nil?
-
-      while index < self.completions.size
-        break unless self.completions[index].starts_with?(line)
-
-        yield self.completions[index]
-        index += 1
+    # Finds all completions that start with line. They are sorted by line length
+    # and alphabetically. This means that shorter matches will show up first.
+    private def self.find_matches(line : String) : Array(String)
+      left_index = self.completions.bsearch_index do |string|
+        string > line && string.starts_with?(line)
       end
+
+      return Array(String).new if left_index.nil?
+
+      first_match = self.completions[left_index]
+      right_index = self.completions.bsearch_index do |string|
+        string > first_match && !string.starts_with?(line)
+      end || self.completions.size
+
+      matches = self.completions[left_index...right_index]
+      matches.sort_by!(&.size) if prefer_shorter_matches?
+      matches
     end
 
     # Sets the callback once using memoization to check if it's already set.
@@ -38,7 +34,9 @@ module Linenoise
       return if @@set_callback
 
       Linenoise.set_completion_callback ->(raw_line : Pointer(UInt8), completion_state : Pointer(LibLinenoise::Completions)) do
-        self.each_completion(String.new(raw_line)) do |completion|
+        line = String.new(raw_line)
+
+        self.find_matches(line).each do |completion|
           Linenoise.add_completion(completion_state, completion)
         end
       end
@@ -50,7 +48,7 @@ module Linenoise
     #
     # Note: This sets a completion callback internally.
     def self.add(completion : String)
-      index = self.find_index(completion)
+      index = self.completions.bsearch_index { |string| string >= completion }
 
       if index.nil?
         self.completions.push(completion)
@@ -84,6 +82,18 @@ module Linenoise
       self.completions.delete_at(index)
     end
 
+    # Prioritizes shorter matches when showing completions.
+    def self.prefer_shorter_matches!
+      @@prefer_shorter_matches = true
+    end
+
+    # Whether shorter matching completions should appear first.
+    private def self.prefer_shorter_matches?
+      @@prefer_shorter_matches
+    end
+
+    @@hint_color : Int32?
+
     # Defaults to dark gray to differentiate it from normal text colors.
     private def self.hint_color : Int32
       @@hint_color ||= Colorize::ColorANSI::DarkGray.to_i
@@ -102,7 +112,7 @@ module Linenoise
       Linenoise.set_hints_callback ->(raw_line : Pointer(UInt8), color : Pointer(Int32), attribute : Pointer(Int32)) : Pointer(UInt8) do
         line = String.new(raw_line)
 
-        self.each_completion(line) do |hint|
+        self.find_matches(line).each do |hint|
           next if hint == line
 
           color.value = self.hint_color

--- a/src/linenoise/completions.cr
+++ b/src/linenoise/completions.cr
@@ -24,6 +24,7 @@ module Linenoise
         string > first_match && !string.starts_with?(line)
       end || self.completions.size
 
+      # TODO: It might make sense to limit this completion size at some point.
       matches = self.completions[left_index...right_index]
       matches.sort_by!(&.size) if prefer_shorter_matches?
       matches


### PR DESCRIPTION
This came up when testing https://github.com/apainintheneck/gitsh. It is sometimes better to show the shortest completions first instead of showing completions in alphabetical order.

It also might be good to add a changelog at some point.

Closes #13