### PR TITLE
Prefer shorter matches v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Build extension
         run: make extension
-      
+
       - name: Build example
         run: make check
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,6 @@ jobs:
       
       - name: Build example
         run: make check
+
+      - name: Run specs
+        run: make specs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- Specs for completion matches in high-level completion wrapper
+
+### Fixed
+
+- Fix bug in prefer shorter matches
+
 ## [0.2.0] - 2024-01-25
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,17 @@ lint:
 fix:
 	crystal tool format
 
-test: extension
+specs:
+	crystal spec --order random
+
+expect: extension
+	@echo ":----------:"
 	expect -f expect/example.expect
 	@echo ":----------:"
 	expect -f expect/completion.expect
+	@echo ":----------:"
+
+test: specs expect
 
 clean:
 	rm -f src/lib/linenoise.o

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Development setup is mostly managed by the Makefile.
 
 Other than that there is the Linenoise extension in `ext/` that can be built with `make extension`. Keep in mind that this also gets installed automatically in a postinstall step when this shard is included as a dependency and `shard install` is run.
 
-Interactive testing is available using the `example/example.cr` program which allows you to check on different line editing features. It can be run with `make example`. The `make test` command runs tests on this example program using an `expect` script so `expect` will need to be installed to run them.
+Interactive testing is available using the `example/example.cr` program which allows you to check on different line editing features. It can be run with `make example`. The `make expect` command runs tests on this example program using an `expect` script so `expect` will need to be installed to run them.
 
 The `make lint` command checks for linting errors and the `make fix` command fixes them automatically.
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Development setup is mostly managed by the Makefile.
 
 Other than that there is the Linenoise extension in `ext/` that can be built with `make extension`. Keep in mind that this also gets installed automatically in a postinstall step when this shard is included as a dependency and `shard install` is run.
 
-Interactive testing is available using the `example/example.cr` program which allows you to check on different line editing features. It can be run with `make example`. The `make specs` option runs the Crystal specs. The `make expect` command runs tests on this example program using an `expect` script so `expect` will need to be installed to run them.
+Interactive testing is available using the `example/example.cr` program which allows you to check on different line editing features. It can be run with `make example`. The `make specs` command runs the Crystal specs. The `make expect` command runs tests on this example program using an `expect` script so `expect` will need to be installed to run them.
 
 The `make lint` command checks for linting errors and the `make fix` command fixes them automatically.
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Development setup is mostly managed by the Makefile.
 
 Other than that there is the Linenoise extension in `ext/` that can be built with `make extension`. Keep in mind that this also gets installed automatically in a postinstall step when this shard is included as a dependency and `shard install` is run.
 
-Interactive testing is available using the `example/example.cr` program which allows you to check on different line editing features. It can be run with `make example`. The `make expect` command runs tests on this example program using an `expect` script so `expect` will need to be installed to run them.
+Interactive testing is available using the `example/example.cr` program which allows you to check on different line editing features. It can be run with `make example`. The `make specs` option runs the Crystal specs. The `make expect` command runs tests on this example program using an `expect` script so `expect` will need to be installed to run them.
 
 The `make lint` command checks for linting errors and the `make fix` command fixes them automatically.
 

--- a/example/completion.cr
+++ b/example/completion.cr
@@ -3,7 +3,7 @@
 require "../src/linenoise"
 
 Linenoise::Completion.add(["hello", "hello there"])
-Linenoise::Completion.add("hello there everyone")
+Linenoise::Completion.add("howdy")
 Linenoise::Completion.enable_hints!
 
 loop do
@@ -11,6 +11,9 @@ loop do
   break if line.nil?
 
   case line
+  when ":prefer_shorter_matches"
+    Linenoise::Completion.prefer_shorter_matches!
+    puts
   when ":exit", ":quit"
     puts "Bye!"
     break

--- a/expect/completion.expect
+++ b/expect/completion.expect
@@ -68,9 +68,63 @@ expect {
 # Try three tab completions.
 send -h -- "h$tab$tab$tab$newline"
 
-# Expect three tab completions to change "h" to "hello there everyone".
+# Expect three tab completions to change "h" to "howdy".
 expect {
-  -exact "hello there everyone$newline$prompt" {}
+  -exact "howdy$newline$prompt" {}
+  timeout timeout_error
+  eof eof_error
+}
+
+# Try four tab completions.
+send -h -- "h$tab$tab$tab$tab$newline"
+
+# Expect four tab completions to leave "h" unchanged since it
+# has cycled through three tab completions to the original input.
+expect {
+  -exact "h$newline$prompt" {}
+  timeout timeout_error
+  eof eof_error
+}
+
+#
+# Test Tab Completions with Shorter Matches Preferred.
+#
+
+send -h -- ":prefer_shorter_matches$newline"
+
+# Expect prompt to load.
+expect {
+  -exact "$newline$prompt" {}
+  timeout timeout_error
+  eof eof_error
+}
+
+# Try one tab completion.
+send -h -- "h$tab$newline"
+
+# Expect one tab completion to change "h" to "hello".
+expect {
+  -exact "hello$newline$prompt" {}
+  timeout timeout_error
+  eof eof_error
+}
+
+# Try two tab completions.
+send -h -- "h$tab$tab$newline"
+
+# Expect two tab completions to change "h" to "howdy".
+expect {
+  -exact "howdy$newline$prompt" {}
+  timeout timeout_error
+  eof eof_error
+}
+
+# Try three tab completions.
+send -h -- "h$tab$tab$tab$newline"
+
+# Expect three tab completions to change "h" to "hello there".
+expect {
+  -exact "hello there$newline$prompt" {}
   timeout timeout_error
   eof eof_error
 }

--- a/spec/linenoise/completion_spec.cr
+++ b/spec/linenoise/completion_spec.cr
@@ -1,0 +1,92 @@
+require "spec"
+require "../spec_helper.cr"
+
+module Linenoise
+  module Completion
+    def self.completions_array
+      @@completions
+    end
+  end
+end
+
+describe Linenoise::Completion do
+  after_each do
+    Linenoise::Completion.reset!
+  end
+
+  describe ".add" do
+    it "adds completions individually" do
+      Linenoise::Completion.add("one")
+      Linenoise::Completion.completions_array.should eq %w[one]
+
+      Linenoise::Completion.add("two")
+      Linenoise::Completion.completions_array.should eq %w[one two]
+
+      Linenoise::Completion.add("three")
+      Linenoise::Completion.completions_array.should eq %w[one three two]
+    end
+
+    it "adds completions in batches" do
+      Linenoise::Completion.add(%w[one two three])
+      Linenoise::Completion.completions_array.should eq %w[one three two]
+    end
+
+    it "does not add duplicates" do
+      Linenoise::Completion.add(%w[one two two three])
+      Linenoise::Completion.add("one")
+      Linenoise::Completion.completions_array.should eq %w[one three two]
+    end
+  end
+
+  describe ".remove" do
+    it "removes completions individually" do
+      Linenoise::Completion.add(%w[one two three])
+
+      Linenoise::Completion.remove("one")
+      Linenoise::Completion.completions_array.should eq %w[three two]
+
+      Linenoise::Completion.remove("two")
+      Linenoise::Completion.completions_array.should eq %w[three]
+    end
+
+    it "skips removing completion when there are none" do
+      Linenoise::Completion.remove("two")
+      Linenoise::Completion.completions_array.should eq [] of String
+    end
+
+    it "skips removing completion that does not exist" do
+      Linenoise::Completion.add(%w[one two three])
+
+      Linenoise::Completion.remove("four")
+      Linenoise::Completion.completions_array.should eq %w[one three two]
+    end
+  end
+
+  describe ".completion_matches" do
+    it "returns no matches to an empty string" do
+      Linenoise::Completion.add(%w[one two three four five six seven])
+
+      Linenoise::Completion.completion_matches("").should eq [] of String
+    end
+
+    it "returns matches in alphabetical order" do
+      Linenoise::Completion.add(%w[one two three four five six seven])
+
+      Linenoise::Completion.completion_matches("t").should eq %w[three two]
+      Linenoise::Completion.completion_matches("s").should eq %w[seven six]
+    end
+
+    describe ".prefer_shorter_matches?" do
+      before_each do
+        Linenoise::Completion.prefer_shorter_matches!
+      end
+
+      it "returns matches in order by string size" do
+        Linenoise::Completion.add(%w[one two three four five six seven])
+
+        Linenoise::Completion.completion_matches("t").should eq %w[two three]
+        Linenoise::Completion.completion_matches("s").should eq %w[six seven]
+      end
+    end
+  end
+end

--- a/spec/linenoise/completion_spec.cr
+++ b/spec/linenoise/completion_spec.cr
@@ -76,7 +76,7 @@ describe Linenoise::Completion do
       Linenoise::Completion.completion_matches("s").should eq %w[seven six]
     end
 
-    describe ".prefer_shorter_matches?" do
+    describe ".prefer_shorter_matches!" do
       before_each do
         Linenoise::Completion.prefer_shorter_matches!
       end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,0 +1,1 @@
+require "../src/linenoise.cr"

--- a/src/linenoise.cr
+++ b/src/linenoise.cr
@@ -1,5 +1,5 @@
 require "./lib/lib_linenoise"
-require "./linenoise/completions"
+require "./linenoise/completion"
 
 module Linenoise
   VERSION = "0.2.0"

--- a/src/linenoise/completion.cr
+++ b/src/linenoise/completion.cr
@@ -124,10 +124,13 @@ module Linenoise
       @@enable_hints = true
     end
 
+    # Completions will be sorted by size instead of alphabetically.
     def self.prefer_shorter_matches!
       @@prefer_shorter_matches = true
     end
 
+    # Resets the completions array, whether shorter matches are preffered,
+    # hint color, and the callbacks. Mostly just needed for testing.
     def self.reset!
       @@completions.clear
       @@prefer_shorter_matches = false

--- a/src/linenoise/completion.cr
+++ b/src/linenoise/completion.cr
@@ -7,33 +7,42 @@ module Linenoise
   # Note: By default completions that start with the current line
   # are shown in alphabetical order.
   module Completion
-    @@hint_color : Int32?
+    # Defaults to dark gray to differentiate it from normal text colors.
+    @@hint_color : Int32 = Colorize::ColorANSI::DarkGray.to_i
 
-    # Memoized completions array that makes it easier to access
-    # completions from the completions callback.
-    private def self.completions : Array(String)
-      @@completions ||= Array(String).new
-    end
+    # By default completions are sorted alphabetically.
+    @@prefer_shorter_matches = false
+
+    # The list of all completions that is sorted alphabetically for searchability.
+    @@completions = [] of String
 
     # Find the index of the closest match to the given line.
     private def self.find_index(line : String) : Int32?
-      self.completions.bsearch_index { |string| string >= line }
+      @@completions.bsearch_index { |string| string >= line }
     end
 
-    # Yields each completion that begins with the given line as a `String`.
-    # The results are sorted by closest match.
-    private def self.each_completion(line : String, &)
-      return if line.empty?
+    # Finds completion matches that begin with the given line.
+    # The results are sorted alphabetically by default.
+    # The results are sorted by size if prefer shorter matches is set.
+    #
+    # Note: This is made public for testing purposes but doesn't need
+    # to be called directly.
+    def self.completion_matches(line : String) : Array(String)
+      matches = [] of String
+      return matches if line.empty?
 
       index = self.find_index(line)
-      return if index.nil?
+      return matches if index.nil?
 
-      while index < self.completions.size
-        break unless self.completions[index].starts_with?(line)
+      while index < @@completions.size
+        break unless @@completions[index].starts_with?(line)
 
-        yield self.completions[index]
+        matches << @@completions[index]
         index += 1
       end
+
+      matches.sort_by!(&.size) if @@prefer_shorter_matches
+      matches
     end
 
     # Sets the callback once using memoization to check if it's already set.
@@ -41,7 +50,8 @@ module Linenoise
       return if @@set_callback
 
       Linenoise.set_completion_callback ->(raw_line : Pointer(UInt8), completion_state : Pointer(LibLinenoise::Completions)) do
-        self.each_completion(String.new(raw_line)) do |completion|
+        line = String.new(raw_line)
+        self.completion_matches(line).each do |completion|
           Linenoise.add_completion(completion_state, completion)
         end
       end
@@ -56,9 +66,9 @@ module Linenoise
       index = self.find_index(completion)
 
       if index.nil?
-        self.completions.push(completion)
-      elsif self.completions[index] != completion
-        self.completions.insert(index, completion)
+        @@completions.push(completion)
+      elsif @@completions[index] != completion
+        @@completions.insert(index, completion)
       end
 
       self.set_callback
@@ -70,9 +80,9 @@ module Linenoise
     def self.add(completions : Array(String))
       return if completions.empty?
 
-      self.completions.concat(completions)
-      self.completions.uniq!
-      self.completions.sort!
+      @@completions.concat(completions)
+      @@completions.uniq!
+      @@completions.sort!
 
       self.set_callback
     end
@@ -82,14 +92,9 @@ module Linenoise
       index = self.find_index(completion)
 
       return if index.nil?
-      return if self.completions[index] != completion
+      return if @@completions[index] != completion
 
-      self.completions.delete_at(index)
-    end
-
-    # Defaults to dark gray to differentiate it from normal text colors.
-    private def self.hint_color : Int32
-      @@hint_color ||= Colorize::ColorANSI::DarkGray.to_i
+      @@completions.delete_at(index)
     end
 
     # Enables hints that match the tab completions.
@@ -97,7 +102,7 @@ module Linenoise
     # them from the characters that the user has already typed.
     #
     # Note: This sets a hints callback internally.
-    def self.enable_hints!(color : Colorize::ColorANSI | Nil = nil)
+    def self.enable_hints!(color : Colorize::ColorANSI? = nil)
       return if @@enable_hints
 
       @@hint_color = color.to_i unless color.nil?
@@ -105,10 +110,10 @@ module Linenoise
       Linenoise.set_hints_callback ->(raw_line : Pointer(UInt8), color : Pointer(Int32), attribute : Pointer(Int32)) : Pointer(UInt8) do
         line = String.new(raw_line)
 
-        self.each_completion(line) do |hint|
+        self.completion_matches(line).each do |hint|
           next if hint == line
 
-          color.value = self.hint_color
+          color.value = @@hint_color
           attribute.value = 0
           return hint.byte_slice(start: line.size).to_unsafe
         end
@@ -117,6 +122,18 @@ module Linenoise
       end
 
       @@enable_hints = true
+    end
+
+    def self.prefer_shorter_matches!
+      @@prefer_shorter_matches = true
+    end
+
+    def self.reset!
+      @@completions.clear
+      @@prefer_shorter_matches = false
+      @@hint_color = Colorize::ColorANSI::DarkGray.to_i
+      @@set_callback = nil
+      @@enable_hints = nil
     end
   end
 end


### PR DESCRIPTION
This time we hopefully won't see the bugs we saw before which caused the previous version to get reverted. It adds an option to sort completions by string size instead of how they're normally sorted which is alphabetically.

Other than that I added some tests for the Linenoise::Completion module and changed the file name from completions.cr to completion.cr. This shouldn't affect anyone using the library because this file is not included directly. The new tests will run on CI unlike the interactive expect tests which only get run locally for now.

This is a follow-up to https://github.com/apainintheneck/crystal-linenoise/pull/18.