### PR TITLE
Fix single line cursor offset bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Fix bug in prefer shorter matches
 - Fix bug in command history on Linux
+- Fix bug in cursor offset position when using escape codes
 
 ## [0.2.0] - 2024-01-25
 

--- a/example/example.cr
+++ b/example/example.cr
@@ -120,7 +120,7 @@ File.tempfile(suffix: "example_history.txt") do |history_file|
   puts HELP_TEXT
 
   loop do
-    line = Linenoise.prompt("hello> ")
+    line = Linenoise.prompt("\033[01;33mhello\033[0m> ")
     break if line.nil?
 
     args = line.split

--- a/expect/example.expect
+++ b/expect/example.expect
@@ -21,7 +21,7 @@ proc eof_error {} {
 # Variables
 #
 
-set prompt "hello> "
+set prompt "\033\[01;33mhello\033\[0m> "
 set newline "\r\n"
 set tab "\t"
 set up "\033\[A"
@@ -35,7 +35,7 @@ spawn crystal run example/example.cr
 
 # Expect initial prompt to load.
 expect {
-  -regex "hello> $" {}
+  -regex "> $" {}
   timeout timeout_error
   eof eof_error
 }

--- a/ext/README.md
+++ b/ext/README.md
@@ -35,3 +35,23 @@ All credit goes to antirez as mentioned in the license includes in this director
   - `https://github.com/emvigo`
 - Note
   - This branch helped fix a bug on Linux with command line history.
+
+---
+
+## Branch: Bug fix when the prompt contains ESC chars
+
+- Last Copied
+  - 2024-02-05
+- Last Commit
+  - Date
+    - 2017-02-28
+  - SHA
+    - be1fc44d69fbf37587b50e4aed42efbe7d925174
+- Branch URL
+  - `https://github.com/antirez/linenoise/pull/135`
+- User URL
+  - `https://github.com/olegat`
+- Note
+  - This branch helped fix a bug where the cursor would be offset
+    when using escape codes because it was calculating the literal
+    offset instead of the visual offset.

--- a/ext/linenoise.c
+++ b/ext/linenoise.c
@@ -322,6 +322,29 @@ failed:
     return 80;
 }
 
+/* Get the length of the string ignoring escape-sequences */
+ static int strlenPerceived(const char* str) {
+ 	int len = 0;
+ 	if (str) {
+ 		int escaping = 0;
+ 		while(*str) {
+ 			if (escaping) { /* was terminating char reached? */
+ 				if(*str >= 0x40 && *str <= 0x7E)
+ 					escaping = 0;
+ 			}
+ 			else if(*str == '\x1b') {
+ 				escaping = 1;
+ 				if (str[1] == '[') str++;
+ 			}
+ 			else {
+ 				len++;
+ 			}
+ 			str++;
+ 		}
+ 	}
+ 	return len;
+ }
+
 /* Clear the screen. Used to handle ctrl+l */
 void linenoiseClearScreen(void) {
     if (write(STDOUT_FILENO,"\x1b[H\x1b[2J",7) <= 0) {
@@ -582,7 +605,7 @@ static void refreshSingleLine(struct linenoiseState *l, int flags) {
 
     if (flags & REFRESH_WRITE) {
         /* Move cursor to original position. */
-        snprintf(seq,sizeof(seq),"\r\x1b[%dC", (int)(pos+plen));
+        snprintf(seq,sizeof(seq),"\r\x1b[%dC", (int)(pos+strlenPerceived(l->prompt)));
         abAppend(&ab,seq,strlen(seq));
     }
 


### PR DESCRIPTION
The cursor based its offset on the literal length of the line not the visual length of the line which caused problems when using escape codes. This fix was pulled in from an upstream branch and it fixes the calculation for the cursor.

Note: This bug is still present in the multiline version though.

- https://github.com/antirez/linenoise/pull/135
- https://github.com/olegat

Thanks for the fix @olegat!