### PR TITLE
Enable -Werror when compiling extension

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: example extension lint fix test clean
 
-CFLAGS = -Wall -Wextra -Wpedantic -c -std=c11 -O2
+CFLAGS = -Wall -Wextra -Wpedantic -Werror -c -std=c11 -O2
 
 default: extension lint test
 


### PR DESCRIPTION
This will make it easier to find any new warnings/errors when adding new patches in the future as it will fail loudly.