### PR TITLE
Remove extra header include and change name of extension changes file

### DIFF
--- a/ext/CHANGES.md
+++ b/ext/CHANGES.md
@@ -1,4 +1,4 @@
-## Linenoise Extension Info
+## Linenoise Extension Changes
 
 All credit goes to antirez as mentioned in the license includes in this directory.
 
@@ -55,3 +55,21 @@ All credit goes to antirez as mentioned in the license includes in this director
   - This branch helped fix a bug where the cursor would be offset
     when using escape codes because it was calculating the literal
     offset instead of the visual offset.
+
+---
+
+## Branch: Remove extra unistd.h include
+
+- Last Copied
+  - 2024-02-10
+- Last Commit
+  - Date
+    - 2017-04-17
+  - SHA
+    - c1afa560fd11825774df8233363c3b611dac6683
+- Branch URL
+  - `https://github.com/antirez/linenoise/pull/139`
+- User URL
+  - `https://github.com/gdawg`
+- Note
+  - This just removes an extra include.

--- a/ext/linenoise.c
+++ b/ext/linenoise.c
@@ -118,7 +118,6 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/ioctl.h>
-#include <unistd.h>
 #include "linenoise.h"
 
 #define LINENOISE_DEFAULT_HISTORY_MAX_LEN 100


### PR DESCRIPTION
- Pulls in the following change by @gdawg which removes an unnecessary header include
  - https://github.com/antirez/linenoise/pull/139
- Changes the name of the documentation file for extension changes